### PR TITLE
Implement broadcast streaming route

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ cd backend
 python main.py
 ```
 
+Opcionalmente, defina variáveis de ambiente para integrar com o LiveKit:
+
+```bash
+export LIVEKIT_URL=wss://seu-servidor-livekit
+export LIVEKIT_API_KEY=sua-chave
+export LIVEKIT_API_SECRET=seu-segredo
+```
+
 3. **API estará disponível em:** `http://localhost:5000`
 
 ### **Frontend (HTML/CSS/JS)**
@@ -96,6 +104,7 @@ npx serve .
 - `POST /api/streams` - Criar nova stream
 - `POST /api/streams/{id}/start` - Iniciar transmissão
 - `POST /api/streams/{id}/stop` - Parar transmissão
+- `POST /api/broadcast/{id}` - Obter token de transmissão (LiveKit)
 
 ### **Gifts**
 - `GET /api/gifts` - Listar gifts disponíveis

--- a/index.html
+++ b/index.html
@@ -157,6 +157,10 @@
                     <button id="start-stream-btn" class="w-full bg-red-600 hover:bg-red-700 text-white py-3 px-4 rounded transition-colors font-medium text-lg">
                         🔴 Iniciar Transmissão ao Vivo
                     </button>
+
+                    <div id="broadcast-session" class="hidden space-y-4 mt-6">
+                        <video id="broadcast-video" class="w-full rounded" autoplay playsinline></video>
+                    </div>
                 </div>
             </div>
         </div>
@@ -251,6 +255,7 @@
         </div>
     </nav>
 
+    <script src="https://unpkg.com/livekit-client/dist/livekit-client.min.js"></script>
     <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enable scalable streaming via LiveKit
- provide `/api/broadcast/<id>` route for tokens
- connect broadcast page to new route and LiveKit
- show local video feed when streaming
- document new endpoint and LiveKit environment variables

## Testing
- `python -m py_compile backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_683f3a3bc4008321a64cb6429a44ce62