### PR TITLE
Fix docker compose version line

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   backend:
     build:


### PR DESCRIPTION
## Summary
- remove deprecated `version: '3'` entry from docker-compose.yml

## Testing
- `docker-compose up -d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f3fd382c483218f8a13dfdad105dd