### PR TITLE
Add env file support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Flask secret key
+SECRET_KEY=change-me
+
+# LiveKit configuration
+LIVEKIT_URL=wss://livekit.example.com
+LIVEKIT_API_KEY=your_api_key
+LIVEKIT_API_SECRET=your_api_secret
+
+# Flask server port
+PORT=5000

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Ignore environment variable files
+.env
+
+# Python
+__pycache__/
+*.py[cod]
+
+# Node
+node_modules/

--- a/README.md
+++ b/README.md
@@ -45,21 +45,19 @@ livehot-package/
 pip install -r requirements.txt
 ```
 
-2. **Executar servidor:**
+2. **Configurar variáveis de ambiente:**
+```bash
+cp .env.example .env
+# Edite o arquivo .env com suas chaves
+```
+3. **Executar servidor:**
 ```bash
 cd backend
 python main.py
 ```
+As variáveis definidas no arquivo `.env` serão carregadas automaticamente. Configure `LIVEKIT_URL`, `LIVEKIT_API_KEY` e `LIVEKIT_API_SECRET` conforme necessário.
 
-Opcionalmente, defina variáveis de ambiente para integrar com o LiveKit:
-
-```bash
-export LIVEKIT_URL=wss://seu-servidor-livekit
-export LIVEKIT_API_KEY=sua-chave
-export LIVEKIT_API_SECRET=seu-segredo
-```
-
-3. **API estará disponível em:** `http://localhost:5000`
+4. **API estará disponível em:** `http://localhost:5000`
 
 ### **Frontend (HTML/CSS/JS)**
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
 from flask import Flask, request, jsonify
 from flask_cors import CORS
 import os
+from dotenv import load_dotenv
 import json
 import uuid
 from datetime import datetime, timedelta
@@ -10,8 +11,10 @@ import hmac
 from functools import wraps
 import jwt
 
+load_dotenv()
+
 app = Flask(__name__)
-app.config['SECRET_KEY'] = 'livehot-secret-key-change-in-production'
+app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'livehot-secret-key-change-in-production')
 
 # LiveKit configuration for scalable streaming
 LIVEKIT_URL = os.environ.get('LIVEKIT_URL', 'wss://livekit.example.com')

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ PyMySQL==1.1.1
 SQLAlchemy==2.0.40
 typing_extensions==4.14.0
 Werkzeug==3.1.3
+python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- load environment variables via dotenv in backend
- provide example `.env.example` and ignore real `.env`
- document environment setup in README
- update dependencies for python-dotenv

## Testing
- `python -m py_compile backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_683f3fa6f5248321b3a86d69fc60197e