### PR TITLE
Make frontend API URL configurable

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -2,7 +2,10 @@ FROM nginx:alpine
 
 COPY index.html /usr/share/nginx/html/index.html
 COPY app.js /usr/share/nginx/html/app.js
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
 
 EXPOSE 80
 
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
 // API Configuration
-const API_BASE_URL = 'https://477h9ikcqnn3.manus.space/api';
+const API_BASE_URL = window.API_BASE_URL || '/api';
 
 // Global state
 let currentUser = null;

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+: ${API_BASE_URL:=/api}
+cat <<EOT > /usr/share/nginx/html/config.js
+window.API_BASE_URL="${API_BASE_URL}";
+EOT
+exec "$@"

--- a/index.html
+++ b/index.html
@@ -256,6 +256,7 @@
     </nav>
 
     <script src="https://unpkg.com/livekit-client/dist/livekit-client.min.js"></script>
+    <script src="config.js"></script>
     <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow `API_BASE_URL` to be configured via global variable
- generate a `config.js` file in the frontend container based on environment variables
- serve the config file before `app.js`

## Testing
- `python3 -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_683f3fcfa3d483218257dae73247d146