### PR TITLE
Fix poetry install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "livehot"
 version = "0.1.0"
 description = "Plataforma LiveHot.app backend"
 authors = ["LiveHot Team <contact@example.com>"]
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
## Summary
- disable package install in pyproject to avoid poetry failure in Docker build

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683f4903b0cc83218e6707a311e6c182