### PR TITLE
Fix Windows startup for frontend container

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+*.sh text eol=lf

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -3,7 +3,8 @@ FROM nginx:alpine
 COPY index.html /usr/share/nginx/html/index.html
 COPY app.js /usr/share/nginx/html/app.js
 COPY docker-entrypoint.sh /docker-entrypoint.sh
-RUN chmod +x /docker-entrypoint.sh
+RUN sed -i 's/\r$//' /docker-entrypoint.sh && \
+    chmod +x /docker-entrypoint.sh
 
 EXPOSE 80
 


### PR DESCRIPTION
## Summary
- force Unix line endings for shell scripts
- normalize line endings during Docker build

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683f4a134b6c83218da48f3aae5d1076