### PR TITLE
Fix API base URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ poetry install
 cp .env.example .env
 # Edite o arquivo .env com suas chaves
 ```
+
+Se estiver executando o frontend fora do Docker (ex.: com `python -m http.server`),
+crie um arquivo `config.js` na raiz do projeto definindo a URL da API:
+
+```javascript
+// config.js
+window.API_BASE_URL = 'http://localhost:5000/api';
+```
+
 3. **Executar servidor:**
 ```bash
 cd backend

--- a/config.js
+++ b/config.js
@@ -1,0 +1,1 @@
+window.API_BASE_URL = 'http://localhost:5000/api';


### PR DESCRIPTION
## Summary
- add config.js for local API base URL
- document config.js usage in README

## Testing
- `pre-commit` *(fails: no tests)*

------
https://chatgpt.com/codex/tasks/task_e_683f4e63a1ac83219a0d099dbe254ea2