### PR TITLE
Fix default API URL in docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ npx serve .
 docker-compose up --build
 ```
 
+O `docker-compose` já define a variável `API_BASE_URL` do frontend para
+`http://backend:5000/api`, permitindo que o navegador acesse a API
+internamente no ambiente Docker.
+
 2. **Frontend disponível em:** `http://localhost:8000`
 3. **Backend disponível em:** `http://localhost:5000`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.frontend
+    environment:
+      - API_BASE_URL=http://backend:5000/api
     ports:
       - "8000:80"
     depends_on:


### PR DESCRIPTION
## Summary
- configure `API_BASE_URL` for the frontend container
- document API base URL usage in Docker instructions

## Testing
- `find backend -name '*.py' | xargs -I {} python3 -m py_compile {}`

------
https://chatgpt.com/codex/tasks/task_e_683f4f5eff6883218229cf795ce453bb