### PR TITLE
Fix API URL resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ docker-compose up --build
 ```
 
 O `docker-compose` já define a variável `API_BASE_URL` do frontend para
-`http://backend:5000/api`, permitindo que o navegador acesse a API
-internamente no ambiente Docker.
+`http://localhost:5000/api`, permitindo que o navegador acesse a API
+do próprio host enquanto os serviços rodam em contêineres.
 
 2. **Frontend disponível em:** `http://localhost:8000`
 3. **Backend disponível em:** `http://localhost:5000`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,8 @@ services:
       context: .
       dockerfile: Dockerfile.frontend
     environment:
-      - API_BASE_URL=http://backend:5000/api
+      # Use localhost so the API is reachable from the host browser
+      - API_BASE_URL=http://localhost:5000/api
     ports:
       - "8000:80"
     depends_on:


### PR DESCRIPTION
## Summary
- update docker-compose to expose API via localhost
- clarify README to use `http://localhost:5000/api`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f5134241883218c59569fa2952ce8