### PR TITLE
Implement ranking and trending features

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ do próprio host enquanto os serviços rodam em contêineres.
 
 ### **Streams**
 - `GET /api/streams` - Listar streams ativas
+- `GET /api/streams?category={nome}` - Filtrar por categoria
+- `GET /api/streams/ranking` - Ranking por viewers em tempo real
+- `GET /api/streams/trending` - Streams em alta por engajamento
+- `GET /api/streams/categories` - Categorias disponíveis
+- `GET /api/streams/recommendations` - Recomendações personalizadas (requer login)
 - `POST /api/streams` - Criar nova stream
 - `POST /api/streams/{id}/start` - Iniciar transmissão
 - `POST /api/streams/{id}/stop` - Parar transmissão
@@ -134,6 +139,9 @@ do próprio host enquanto os serviços rodam em contêineres.
 ### **Carteira**
 - `GET /api/wallet` - Dados da carteira
 - `POST /api/wallet/purchase` - Comprar moedas
+
+### **Usuário**
+- `PUT /api/users/preferences` - Atualizar categorias favoritas
 
 ## 🎯 **Status do Projeto**
 

--- a/app.js
+++ b/app.js
@@ -52,8 +52,25 @@ const api = {
     },
 
     // Streams
-    async getStreams(page = 1, limit = 20) {
-        return this.request(`/streams?page=${page}&limit=${limit}`);
+    async getStreams(page = 1, limit = 20, category = '') {
+        const catQuery = category ? `&category=${encodeURIComponent(category)}` : '';
+        return this.request(`/streams?page=${page}&limit=${limit}${catQuery}`);
+    },
+
+    async getRanking(limit = 10) {
+        return this.request(`/streams/ranking?limit=${limit}`);
+    },
+
+    async getTrending(limit = 10) {
+        return this.request(`/streams/trending?limit=${limit}`);
+    },
+
+    async getCategories() {
+        return this.request('/streams/categories');
+    },
+
+    async getRecommendations(limit = 5) {
+        return this.request(`/streams/recommendations?limit=${limit}`);
     },
 
     async createStream(streamData) {
@@ -84,6 +101,13 @@ const api = {
         return this.request('/wallet/purchase', {
             method: 'POST',
             body: JSON.stringify({ package: packageType }),
+        });
+    },
+
+    async updatePreferences(categories) {
+        return this.request('/users/preferences', {
+            method: 'PUT',
+            body: JSON.stringify({ categories }),
         });
     },
 };
@@ -238,11 +262,11 @@ function cancelLoginTimer() {
 }
 
 // Stream functions
-async function loadStreams() {
+async function loadStreams(category = '') {
     const container = document.getElementById('feed');
     try {
         container.innerHTML = `<div class="text-center text-slate-400 py-12">Carregando streams...</div>`;
-        const response = await api.getStreams();
+        const response = await api.getStreams(1, 20, category);
         const streams = response.data.streams;
         if (streams.length === 0) {
             container.innerHTML = `<div class="text-center text-slate-400 py-12">Nenhuma stream ativa no momento</div>`;


### PR DESCRIPTION
## Summary
- add ranking/trending API endpoints
- support categories and recommendations
- track gift count for streams
- allow user preference updates
- expose new JS API helpers
- document endpoints in README

## Testing
- `python -m py_compile backend/main.py`
- `python -m py_compile $(git ls-files '*.py')`
- `node -e "require('fs').accessSync('app.js')"`


------
https://chatgpt.com/codex/tasks/task_e_683f571ebfc8832180dc6078dc5f6175