### PR TITLE
Add PWA support

### DIFF
--- a/app.js
+++ b/app.js
@@ -383,6 +383,28 @@ async function startStreamBroadcast() {
 document.addEventListener('DOMContentLoaded', async function() {
     // Initialize app
     await checkAuth();
+
+    // Register service worker and background sync
+    if ('serviceWorker' in navigator) {
+        try {
+            const reg = await navigator.serviceWorker.register('service-worker.js');
+            if ('SyncManager' in window) {
+                await reg.sync.register('sync-data');
+            }
+        } catch (err) {
+            console.error('Service worker registration failed', err);
+        }
+    }
+
+    // Request notification permission
+    if (window.Notification && Notification.permission === 'default') {
+        Notification.requestPermission();
+    }
+
+    // Subscribe to push notifications
+    if (Notification.permission === 'granted') {
+        subscribePush();
+    }
     
     // Show navigation and hide loading
     hideElement('loading');
@@ -482,4 +504,16 @@ window.showPage = showPage;
 window.fillDemoCredentials = fillDemoCredentials;
 window.toggleAuth = toggleAuth;
 window.purchaseCoins = purchaseCoins;
+
+async function subscribePush() {
+    if (!('serviceWorker' in navigator)) return;
+    try {
+        const registration = await navigator.serviceWorker.ready;
+        await registration.pushManager.subscribe({
+            userVisibleOnly: true
+        });
+    } catch (err) {
+        console.error('Push subscription failed', err);
+    }
+}
 

--- a/icons/icon.svg
+++ b/icons/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" fill="#d946ef" />
+  <text x="50%" y="55%" font-size="280" fill="white" text-anchor="middle" font-family="Arial" dy=".35em">LH</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>LiveHot - Plataforma Premium de Live Streaming</title>
+    <link rel="manifest" href="manifest.json">
+    <meta name="theme-color" content="#d946ef">
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
         .line-clamp-2 {

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "LiveHot",
+  "short_name": "LiveHot",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#111827",
+  "theme_color": "#d946ef",
+  "icons": [
+    {
+      "src": "icons/icon.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,60 @@
+const CACHE_NAME = 'livehot-cache-v1';
+const OFFLINE_URLS = [
+  '/',
+  '/index.html',
+  '/app.js',
+  '/config.js',
+  '/manifest.json',
+  '/icons/icon.svg',
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(OFFLINE_URLS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(
+        keys.map(key => {
+          if (key !== CACHE_NAME) {
+            return caches.delete(key);
+          }
+        })
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then(cached => {
+      return (
+        cached ||
+        fetch(event.request).catch(() => caches.match('/index.html'))
+      );
+    })
+  );
+});
+
+self.addEventListener('push', event => {
+  const data = event.data ? event.data.json() : {};
+  const title = data.title || 'LiveHot';
+  const options = {
+    body: data.body || '',
+    icon: '/icons/icon.svg',
+    badge: '/icons/icon.svg',
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('sync', event => {
+  if (event.tag === 'sync-data') {
+    event.waitUntil(fetch('/api/sync').catch(() => {}));
+  }
+});


### PR DESCRIPTION
## Summary
- add `manifest.json` with basic metadata and icon
- add `service-worker.js` for offline cache, push notifications, and background sync
- register service worker and push subscription in `app.js`
- link manifest and theme color in `index.html`
- add an SVG icon

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_683f572dd3fc8321ae16473fd0260833