### PR TITLE
Implement SEO share pages and sitemap

### DIFF
--- a/app.js
+++ b/app.js
@@ -97,7 +97,7 @@ function hideElement(id) {
     document.getElementById(id).classList.add('hidden');
 }
 
-function showPage(pageId) {
+function showPage(pageId, streamId = null) {
     // Hide all pages
     document.querySelectorAll('.page').forEach(page => {
         page.classList.add('hidden');
@@ -120,7 +120,7 @@ function showPage(pageId) {
     // Load page content
     switch(pageId) {
         case 'home':
-            loadStreams();
+            loadStreams(streamId);
             break;
         case 'wallet':
             loadWallet();
@@ -238,7 +238,7 @@ function cancelLoginTimer() {
 }
 
 // Stream functions
-async function loadStreams() {
+async function loadStreams(highlightId = null) {
     const container = document.getElementById('feed');
     try {
         container.innerHTML = `<div class="text-center text-slate-400 py-12">Carregando streams...</div>`;
@@ -249,7 +249,7 @@ async function loadStreams() {
             return;
         }
         container.innerHTML = streams.map(stream => `
-            <div class="slide">
+            <div class="slide" data-stream-id="${stream.id}">
                 <img src="${stream.thumbnailUrl}" alt="${stream.title}" class="w-full h-full object-cover" onerror="this.src='${stream.thumbnailUrl}'" />
                 <div class="absolute bottom-0 left-0 p-4 text-white bg-black/50 w-full">
                     <div class="font-bold">${stream.streamer.displayName}</div>
@@ -258,12 +258,18 @@ async function loadStreams() {
                 <div class="actions">
                     <button>❤️</button>
                     <button>🎁</button>
-                    <button>🔗</button>
+                    <button onclick="shareStream('${stream.id}')">🔗</button>
                     <button>➕</button>
                 </div>
                 <div class="chat"></div>
             </div>
         `).join('');
+        if (highlightId) {
+            const slide = container.querySelector(`[data-stream-id="${highlightId}"]`);
+            if (slide) {
+                slide.scrollIntoView({behavior: 'smooth'});
+            }
+        }
     } catch (error) {
         container.innerHTML = `
             <div class="text-center text-red-400 py-12">
@@ -275,6 +281,15 @@ async function loadStreams() {
             </div>
         `;
     }
+}
+
+function shareStream(id) {
+    const url = `${window.location.origin}/streams/${id}`;
+    navigator.clipboard.writeText(url).then(() => {
+        showNotification('Link copiado para a área de transferência!', 'success');
+    }).catch(() => {
+        window.open(url, '_blank');
+    });
 }
 
 // Wallet functions
@@ -389,8 +404,11 @@ document.addEventListener('DOMContentLoaded', async function() {
     showElement('app');
     showElement('navigation');
     
-    // Show home page by default
-    showPage('home');
+    const params = new URLSearchParams(window.location.search);
+    const streamParam = params.get('stream');
+
+    // Show home page by default, highlighting stream if provided
+    showPage('home', streamParam);
     
     startLoginTimer();
     document.getElementById("login-modal-login").addEventListener("click", () => { cancelLoginTimer(); showPage("login"); });
@@ -482,4 +500,5 @@ window.showPage = showPage;
 window.fillDemoCredentials = fillDemoCredentials;
 window.toggleAuth = toggleAuth;
 window.purchaseCoins = purchaseCoins;
+window.shareStream = shareStream;
 

--- a/backend/templates/share.html
+++ b/backend/templates/share.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="utf-8">
+    <title>{{ stream.title }} - LiveHot</title>
+    <meta name="description" content="{{ stream.description }}">
+    <meta property="og:title" content="{{ stream.title }}">
+    <meta property="og:description" content="{{ stream.description }}">
+    <meta property="og:type" content="video.other">
+    <meta property="og:url" content="{{ url }}">
+    {% if stream.thumbnailUrl %}
+    <meta property="og:image" content="{{ stream.thumbnailUrl }}">
+    {% endif %}
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:title" content="{{ stream.title }}">
+    <meta property="twitter:description" content="{{ stream.description }}">
+    {% if stream.thumbnailUrl %}
+    <meta property="twitter:image" content="{{ stream.thumbnailUrl }}">
+    {% endif %}
+    <script>
+        // Redirect to frontend with deep link
+        window.location.href = '/?stream={{ stream.id }}';
+    </script>
+</head>
+<body>
+    <p>Redirecionando para a stream...</p>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta property="og:title" content="LiveHot - Plataforma Premium de Live Streaming">
+    <meta property="og:description" content="Assista e compartilhe lives incríveis na LiveHot">
+    <meta property="og:type" content="website">
     <title>LiveHot - Plataforma Premium de Live Streaming</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <style>


### PR DESCRIPTION
## Summary
- add Open Graph tags to main index
- create dynamic share page template
- generate sitemap from live streams
- integrate share links and deep linking in frontend

## Testing
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_683f5761ca8c832182137dfd8658530b