### PR TITLE
Add auth blueprint placeholder

### DIFF
--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -1,0 +1,1 @@
+from .auth import auth_bp

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -1,0 +1,18 @@
+from flask import Blueprint, request, jsonify
+
+auth_bp = Blueprint('auth', __name__)
+
+@auth_bp.route('/login', methods=['POST'])
+def login():
+    # TODO: Mover código de login do main.py
+    pass
+
+@auth_bp.route('/register', methods=['POST'])
+def register():
+    # TODO: Mover código de register do main.py
+    pass
+
+@auth_bp.route('/me', methods=['GET'])
+def get_current_user():
+    # TODO: Mover código do main.py
+    pass


### PR DESCRIPTION
## Summary
- create `auth` blueprint module for future login, register, and user retrieval endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f6d267c6883219035cf7fc00f9ac9