### PR TITLE
Add new Flask route blueprints

### DIFF
--- a/backend/routes/gifts.py
+++ b/backend/routes/gifts.py
@@ -1,0 +1,29 @@
+from flask import Blueprint, request, jsonify
+from services.gift_service import GiftService
+from utils.decorators import token_required
+
+gifts_bp = Blueprint('gifts', __name__)
+gift_service = GiftService()
+
+@gifts_bp.route('/', methods=['GET'])
+def get_gifts():
+    result = gift_service.get_available_gifts()
+    return jsonify({'success': True, 'data': {'gifts': result}})
+
+@gifts_bp.route('/send', methods=['POST'])
+@token_required
+def send_gift():
+    from flask import g
+    data = request.get_json()
+    gift_id = data.get('giftId')
+    recipient_id = data.get('recipientId')
+    amount = data.get('amount', 1)
+    
+    if not gift_id or not recipient_id:
+        return jsonify({'success': False, 'error': {'message': 'Gift ID and recipient ID required'}}), 400
+    
+    try:
+        result = gift_service.send_gift(g.current_user['id'], recipient_id, gift_id, amount)
+        return jsonify({'success': True, 'data': result})
+    except ValueError as e:
+        return jsonify({'success': False, 'error': {'message': str(e)}}), 400

--- a/backend/routes/streams.py
+++ b/backend/routes/streams.py
@@ -1,0 +1,66 @@
+from flask import Blueprint, request, jsonify
+from services.stream_service import StreamService
+from utils.decorators import token_required
+import uuid
+
+streams_bp = Blueprint('streams', __name__)
+stream_service = StreamService()
+
+@streams_bp.route('/', methods=['GET'])
+def get_streams():
+    page = int(request.args.get('page', 1))
+    limit = int(request.args.get('limit', 20))
+    
+    result = stream_service.get_active_streams(page, limit)
+    return jsonify({'success': True, 'data': result})
+
+@streams_bp.route('/', methods=['POST'])
+@token_required
+def create_stream():
+    from flask import g
+    data = request.get_json()
+    
+    if not g.current_user.get('isStreamer'):
+        return jsonify({'success': False, 'error': {'message': 'Only streamers can create streams'}}), 403
+    
+    stream_data = {
+        'title': data.get('title', 'Untitled Stream'),
+        'description': data.get('description', ''),
+        'category': data.get('category', 'Entertainment'),
+        'isPrivate': data.get('isPrivate', False)
+    }
+    
+    result = stream_service.create_stream(g.current_user['id'], stream_data)
+    return jsonify({'success': True, 'data': result}), 201
+
+@streams_bp.route('/<stream_id>', methods=['GET'])
+def get_stream(stream_id):
+    result = stream_service.get_stream_by_id(stream_id)
+    if not result:
+        return jsonify({'success': False, 'error': {'message': 'Stream not found'}}), 404
+    
+    return jsonify({'success': True, 'data': result})
+
+@streams_bp.route('/<stream_id>/start', methods=['POST'])
+@token_required
+def start_stream(stream_id):
+    from flask import g
+    try:
+        result = stream_service.start_stream(stream_id, g.current_user['id'])
+        return jsonify({'success': True, 'data': result})
+    except ValueError as e:
+        return jsonify({'success': False, 'error': {'message': str(e)}}), 403
+    except Exception as e:
+        return jsonify({'success': False, 'error': {'message': 'Stream not found'}}), 404
+
+@streams_bp.route('/<stream_id>/stop', methods=['POST'])
+@token_required
+def stop_stream(stream_id):
+    from flask import g
+    try:
+        result = stream_service.stop_stream(stream_id, g.current_user['id'])
+        return jsonify({'success': True, 'data': result})
+    except ValueError as e:
+        return jsonify({'success': False, 'error': {'message': str(e)}}), 403
+    except Exception as e:
+        return jsonify({'success': False, 'error': {'message': 'Stream not found'}}), 404

--- a/backend/routes/wallet.py
+++ b/backend/routes/wallet.py
@@ -1,0 +1,36 @@
+from flask import Blueprint, request, jsonify
+from services.wallet_service import WalletService
+from utils.decorators import token_required
+
+wallet_bp = Blueprint('wallet', __name__)
+wallet_service = WalletService()
+
+@wallet_bp.route('/', methods=['GET'])
+@token_required
+def get_wallet():
+    from flask import g
+    result = wallet_service.get_wallet_info(g.current_user['id'])
+    return jsonify({'success': True, 'data': result})
+
+@wallet_bp.route('/purchase', methods=['POST'])
+@token_required
+def purchase_coins():
+    from flask import g
+    data = request.get_json()
+    package = data.get('package', 'basic')
+    
+    try:
+        result = wallet_service.purchase_coins(g.current_user['id'], package)
+        return jsonify({'success': True, 'data': result})
+    except ValueError as e:
+        return jsonify({'success': False, 'error': {'message': str(e)}}), 400
+
+@wallet_bp.route('/transactions', methods=['GET'])
+@token_required
+def get_transactions():
+    from flask import g
+    page = int(request.args.get('page', 1))
+    limit = int(request.args.get('limit', 20))
+    
+    result = wallet_service.get_transactions(g.current_user['id'], page, limit)
+    return jsonify({'success': True, 'data': result})


### PR DESCRIPTION
## Summary
- add route blueprints for streams, gifts, and wallet features
- provide placeholders for new API endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f70697dbc8321990a9e9b16bd0695