### PR TITLE
Fix manifest 404 in frontend container

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -2,6 +2,9 @@ FROM nginx:alpine
 
 COPY index.html /usr/share/nginx/html/index.html
 COPY app.js /usr/share/nginx/html/app.js
+COPY manifest.json /usr/share/nginx/html/manifest.json
+COPY service-worker.js /usr/share/nginx/html/service-worker.js
+COPY icons /usr/share/nginx/html/icons
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN sed -i 's/\r$//' /docker-entrypoint.sh && \
     chmod +x /docker-entrypoint.sh


### PR DESCRIPTION
## Summary
- copy PWA files (manifest, service worker, icons) into nginx image so the frontend serves them

## Testing
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_683f7463371c8321a7948ec367a63ea1