### PR TITLE
Fix LiveKit key env variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
   livekit:
     image: livekit/livekit-server
     environment:
-      - LIVEKIT_KEYS=${LIVEKIT_API_KEY}:${LIVEKIT_API_SECRET}
+      - LIVEKIT_KEYS="${LIVEKIT_API_KEY}: ${LIVEKIT_API_SECRET}"
     command: --node-ip=0.0.0.0
     ports:
       - "7880:7880"


### PR DESCRIPTION
## Summary
- ensure the LiveKit server receives API key and secret separated by a space

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7484223483219f52409e54a0754f