### PR TITLE
Add React base project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@ __pycache__/
 
 # Node
 node_modules/
+**/node_modules/
+
+# Build output
+dist/
+**/dist/
 
 # Poetry
 .poetry

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "start": "vite preview"
   },
   "dependencies": {
     "@livekit/client": "^2.0.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,12 +1,17 @@
 import React from 'react';
-import { Routes, Route } from 'react-router-dom';
-import Home from './pages/Home';
+import VideoPlayer from './components/VideoPlayer';
+import ChatBox from './components/chat/ChatBox';
+import GiftButton from './components/gifts/GiftButton';
 
 function App() {
   return (
-    <Routes>
-      <Route path="/" element={<Home />} />
-    </Routes>
+    <div className="min-h-screen flex flex-col">
+      <VideoPlayer />
+      <ChatBox />
+      <div className="p-4">
+        <GiftButton />
+      </div>
+    </div>
   );
 }
 

--- a/frontend/src/components/VideoPlayer.jsx
+++ b/frontend/src/components/VideoPlayer.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function VideoPlayer() {
+  return (
+    <div className="bg-black h-64 w-full flex items-center justify-center text-white">
+      Video Player
+    </div>
+  );
+}
+
+export default VideoPlayer;

--- a/frontend/src/components/chat/ChatBox.jsx
+++ b/frontend/src/components/chat/ChatBox.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function ChatBox() {
+  return (
+    <div className="p-4 border-t h-48 overflow-y-auto">
+      <p className="text-center text-slate-500">Chat em tempo real</p>
+    </div>
+  );
+}
+
+export default ChatBox;

--- a/frontend/src/components/gifts/GiftButton.jsx
+++ b/frontend/src/components/gifts/GiftButton.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+function GiftButton() {
+  return (
+    <button className="px-4 py-2 bg-pink-600 text-white rounded">Enviar Presente</button>
+  );
+}
+
+export default GiftButton;

--- a/frontend/src/hooks/useSocket.js
+++ b/frontend/src/hooks/useSocket.js
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+import { io } from 'socket.io-client';
+
+export default function useSocket(url) {
+  useEffect(() => {
+    const socket = io(url);
+    return () => {
+      socket.disconnect();
+    };
+  }, [url]);
+}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,9 +1,16 @@
 import React from 'react';
+import VideoPlayer from '../components/VideoPlayer';
+import ChatBox from '../components/chat/ChatBox';
+import GiftButton from '../components/gifts/GiftButton';
 
 function Home() {
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold">Welcome to LiveHot React</h1>
+    <div className="min-h-screen flex flex-col">
+      <VideoPlayer />
+      <ChatBox />
+      <div className="p-4">
+        <GiftButton />
+      </div>
     </div>
   );
 }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+const API = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api',
+});
+
+export default API;

--- a/frontend/src/store/chatSlice.js
+++ b/frontend/src/store/chatSlice.js
@@ -1,0 +1,15 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const chatSlice = createSlice({
+  name: 'chat',
+  initialState: { messages: [] },
+  reducers: {
+    addMessage(state, action) {
+      state.messages.push(action.payload);
+    },
+  },
+});
+
+export const { addMessage } = chatSlice.actions;
+
+export default chatSlice.reducer;

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1,5 +1,8 @@
 import { configureStore } from '@reduxjs/toolkit';
+import chatReducer from './chatSlice';
 
 export default configureStore({
-  reducer: {},
+  reducer: {
+    chat: chatReducer,
+  },
 });

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- initialize React app skeleton in `frontend`
- add example components for video, chat, and gifts
- add Redux slice and socket hook
- configure Vite with path alias
- update `.gitignore` for Node and build output
- provide build/start script in `package.json`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f7a1472ec8321a33ea82a83f8df11