### PR TITLE
Add login and registration modals

### DIFF
--- a/frontend/src/components/auth/LoginModal.js
+++ b/frontend/src/components/auth/LoginModal.js
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import API from '../../services/api';
+
+function LoginModal({ isOpen, onClose, onLogin }) {
+  const { register, handleSubmit, reset } = useForm();
+  const [error, setError] = useState('');
+
+  const onSubmit = async (data) => {
+    try {
+      const res = await API.post('/auth/login', data);
+      const { token, user } = res.data.data;
+      localStorage.setItem('token', token);
+      if (onLogin) {
+        onLogin(user);
+      }
+      reset();
+      setError('');
+      onClose();
+    } catch (err) {
+      console.error(err);
+      setError('Falha ao fazer login');
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white p-6 rounded w-80 shadow-lg">
+        <h2 className="text-lg font-bold mb-4">Entrar</h2>
+        {error && <p className="text-red-600 mb-2 text-sm">{error}</p>}
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <input
+            type="email"
+            placeholder="Email"
+            className="w-full p-2 border rounded"
+            {...register('email', { required: true })}
+          />
+          <input
+            type="password"
+            placeholder="Senha"
+            className="w-full p-2 border rounded"
+            {...register('password', { required: true })}
+          />
+          <div className="flex justify-end space-x-2">
+            <button
+              type="button"
+              className="px-4 py-2 bg-gray-200 rounded"
+              onClick={onClose}
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              className="px-4 py-2 bg-pink-600 text-white rounded"
+            >
+              Entrar
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default LoginModal;

--- a/frontend/src/components/auth/RegisterModal.js
+++ b/frontend/src/components/auth/RegisterModal.js
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import API from '../../services/api';
+
+function RegisterModal({ isOpen, onClose, onRegister }) {
+  const { register, handleSubmit, reset } = useForm();
+  const [error, setError] = useState('');
+
+  const onSubmit = async (data) => {
+    try {
+      const res = await API.post('/auth/register', data);
+      const { token, user } = res.data.data;
+      localStorage.setItem('token', token);
+      if (onRegister) {
+        onRegister(user);
+      }
+      reset();
+      setError('');
+      onClose();
+    } catch (err) {
+      console.error(err);
+      setError('Falha ao registrar');
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white p-6 rounded w-80 shadow-lg">
+        <h2 className="text-lg font-bold mb-4">Criar Conta</h2>
+        {error && <p className="text-red-600 mb-2 text-sm">{error}</p>}
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
+          <input
+            type="text"
+            placeholder="Nome de usuário"
+            className="w-full p-2 border rounded"
+            {...register('username', { required: true })}
+          />
+          <input
+            type="text"
+            placeholder="Nome para exibição"
+            className="w-full p-2 border rounded"
+            {...register('displayName', { required: true })}
+          />
+          <input
+            type="email"
+            placeholder="Email"
+            className="w-full p-2 border rounded"
+            {...register('email', { required: true })}
+          />
+          <input
+            type="password"
+            placeholder="Senha"
+            className="w-full p-2 border rounded"
+            {...register('password', { required: true })}
+          />
+          <div className="flex justify-end space-x-2 pt-2">
+            <button
+              type="button"
+              className="px-4 py-2 bg-gray-200 rounded"
+              onClick={onClose}
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              className="px-4 py-2 bg-pink-600 text-white rounded"
+            >
+              Registrar
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default RegisterModal;


### PR DESCRIPTION
## Summary
- add `LoginModal` component
- add `RegisterModal` component

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683f83ca99e883218791c4f4d0fd12a0