### PR TITLE
Create Redux slices and update store

### DIFF
--- a/frontend/src/store/authSlice.js
+++ b/frontend/src/store/authSlice.js
@@ -1,0 +1,18 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState: { user: null },
+  reducers: {
+    login(state, action) {
+      state.user = action.payload;
+    },
+    logout(state) {
+      state.user = null;
+    },
+  },
+});
+
+export const { login, logout } = authSlice.actions;
+
+export default authSlice.reducer;

--- a/frontend/src/store/giftSlice.js
+++ b/frontend/src/store/giftSlice.js
@@ -1,0 +1,18 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const giftSlice = createSlice({
+  name: 'gift',
+  initialState: { gifts: [] },
+  reducers: {
+    addGift(state, action) {
+      state.gifts.push(action.payload);
+    },
+    clearGifts(state) {
+      state.gifts = [];
+    },
+  },
+});
+
+export const { addGift, clearGifts } = giftSlice.actions;
+
+export default giftSlice.reducer;

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1,8 +1,16 @@
 import { configureStore } from '@reduxjs/toolkit';
+import authReducer from './authSlice';
+import streamReducer from './streamSlice';
+import giftReducer from './giftSlice';
+import uiReducer from './uiSlice';
 import chatReducer from './chatSlice';
 
 export default configureStore({
   reducer: {
+    auth: authReducer,
+    stream: streamReducer,
+    gift: giftReducer,
+    ui: uiReducer,
     chat: chatReducer,
   },
 });

--- a/frontend/src/store/streamSlice.js
+++ b/frontend/src/store/streamSlice.js
@@ -1,0 +1,21 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const streamSlice = createSlice({
+  name: 'stream',
+  initialState: { streams: [], current: null },
+  reducers: {
+    addStream(state, action) {
+      state.streams.push(action.payload);
+    },
+    setCurrentStream(state, action) {
+      state.current = action.payload;
+    },
+    setStreams(state, action) {
+      state.streams = action.payload;
+    },
+  },
+});
+
+export const { addStream, setCurrentStream, setStreams } = streamSlice.actions;
+
+export default streamSlice.reducer;

--- a/frontend/src/store/uiSlice.js
+++ b/frontend/src/store/uiSlice.js
@@ -1,0 +1,21 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const uiSlice = createSlice({
+  name: 'ui',
+  initialState: { loading: false, error: null },
+  reducers: {
+    setLoading(state, action) {
+      state.loading = action.payload;
+    },
+    setError(state, action) {
+      state.error = action.payload;
+    },
+    clearError(state) {
+      state.error = null;
+    },
+  },
+});
+
+export const { setLoading, setError, clearError } = uiSlice.actions;
+
+export default uiSlice.reducer;


### PR DESCRIPTION
## Summary
- add auth, stream, gift and UI slices
- register new slices in the Redux store

## Testing
- `pytest -q`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683f83ed1cc88321acd57261d584035a