### PR TITLE
Add essential frontend hooks

### DIFF
--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -1,0 +1,41 @@
+import { useState, useEffect } from 'react';
+import API from '../services/api';
+
+export default function useAuth() {
+  const [user, setUser] = useState(null);
+  const [token, setToken] = useState(() => localStorage.getItem('token'));
+
+  useEffect(() => {
+    if (token) {
+      API.defaults.headers.common.Authorization = `Bearer ${token}`;
+      API.get('/auth/me')
+        .then(res => setUser(res.data.data))
+        .catch(() => setUser(null));
+    } else {
+      delete API.defaults.headers.common.Authorization;
+      setUser(null);
+    }
+  }, [token]);
+
+  const login = async (email, password) => {
+    const res = await API.post('/auth/login', { email, password });
+    setToken(res.data.data.token);
+    setUser(res.data.data.user);
+    localStorage.setItem('token', res.data.data.token);
+  };
+
+  const register = async (payload) => {
+    const res = await API.post('/auth/register', payload);
+    setToken(res.data.data.token);
+    setUser(res.data.data.user);
+    localStorage.setItem('token', res.data.data.token);
+  };
+
+  const logout = () => {
+    setUser(null);
+    setToken(null);
+    localStorage.removeItem('token');
+  };
+
+  return { user, token, login, register, logout };
+}

--- a/frontend/src/hooks/useChat.js
+++ b/frontend/src/hooks/useChat.js
@@ -1,0 +1,29 @@
+import { useEffect, useState, useCallback } from 'react';
+import { io } from 'socket.io-client';
+
+export default function useChat(url) {
+  const [socket, setSocket] = useState(null);
+  const [messages, setMessages] = useState([]);
+
+  useEffect(() => {
+    const s = io(url);
+    setSocket(s);
+    s.on('message', (msg) => {
+      setMessages((m) => [...m, msg]);
+    });
+    return () => {
+      s.disconnect();
+    };
+  }, [url]);
+
+  const sendMessage = useCallback(
+    (msg) => {
+      if (socket) {
+        socket.emit('message', msg);
+      }
+    },
+    [socket]
+  );
+
+  return { socket, messages, sendMessage };
+}

--- a/frontend/src/hooks/useGifts.js
+++ b/frontend/src/hooks/useGifts.js
@@ -1,0 +1,19 @@
+import { useState, useCallback } from 'react';
+import API from '../services/api';
+
+export default function useGifts() {
+  const [gifts, setGifts] = useState([]);
+
+  const fetchGifts = useCallback(async () => {
+    const res = await API.get('/gifts');
+    setGifts(res.data.data.gifts);
+    return res.data.data.gifts;
+  }, []);
+
+  const sendGift = useCallback(async ({ giftId, recipientId, amount = 1 }) => {
+    const res = await API.post('/gifts/send', { giftId, recipientId, amount });
+    return res.data.data;
+  }, []);
+
+  return { gifts, fetchGifts, sendGift };
+}

--- a/frontend/src/hooks/useStreams.js
+++ b/frontend/src/hooks/useStreams.js
@@ -1,0 +1,41 @@
+import { useState, useCallback } from 'react';
+import API from '../services/api';
+
+export default function useStreams() {
+  const [streams, setStreams] = useState([]);
+
+  const fetchStreams = useCallback(async (params = {}) => {
+    const res = await API.get('/streams', { params });
+    setStreams(res.data.data.streams);
+    return res.data.data;
+  }, []);
+
+  const getStream = useCallback(async (id) => {
+    const res = await API.get(`/streams/${id}`);
+    return res.data.data;
+  }, []);
+
+  const createStream = useCallback(async (payload) => {
+    const res = await API.post('/streams', payload);
+    return res.data.data;
+  }, []);
+
+  const startStream = useCallback(async (id) => {
+    const res = await API.post(`/streams/${id}/start`);
+    return res.data.data;
+  }, []);
+
+  const stopStream = useCallback(async (id) => {
+    const res = await API.post(`/streams/${id}/stop`);
+    return res.data.data;
+  }, []);
+
+  return {
+    streams,
+    fetchStreams,
+    getStream,
+    createStream,
+    startStream,
+    stopStream,
+  };
+}


### PR DESCRIPTION
## Summary
- add core hooks for auth, streams, chat and gifts

## Testing
- `npm test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f83dc23f083219e545f5956ce3671