### PR TITLE
Add websocket and storage services

### DIFF
--- a/frontend/src/services/storage.js
+++ b/frontend/src/services/storage.js
@@ -1,0 +1,18 @@
+export function setItem(key, value) {
+  localStorage.setItem(key, JSON.stringify(value));
+}
+
+export function getItem(key, defaultValue = null) {
+  const item = localStorage.getItem(key);
+  try {
+    return item ? JSON.parse(item) : defaultValue;
+  } catch {
+    return defaultValue;
+  }
+}
+
+export function removeItem(key) {
+  localStorage.removeItem(key);
+}
+
+export default { setItem, getItem, removeItem };

--- a/frontend/src/services/websocket.js
+++ b/frontend/src/services/websocket.js
@@ -1,0 +1,29 @@
+import { io } from 'socket.io-client';
+
+let socket = null;
+
+export function connect(url = import.meta.env.VITE_WS_URL || 'ws://localhost:5000') {
+  socket = io(url);
+  return socket;
+}
+
+export function disconnect() {
+  if (socket) {
+    socket.disconnect();
+    socket = null;
+  }
+}
+
+export function on(event, callback) {
+  if (socket) {
+    socket.on(event, callback);
+  }
+}
+
+export function emit(event, payload) {
+  if (socket) {
+    socket.emit(event, payload);
+  }
+}
+
+export default { connect, disconnect, on, emit };


### PR DESCRIPTION
## Summary
- add websocket service to wrap socket.io
- add storage helper for localStorage

## Testing
- `npm test` *(fails: Error: no test specified)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683f840608c48321afefab04b27e2b5a