### PR TITLE
Add config and constants modules

### DIFF
--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -1,0 +1,41 @@
+/**
+ * API endpoint definitions used throughout the app.
+ * Paths are relative to the base URL configured in services/api.js
+ */
+const API = {
+  AUTH: {
+    LOGIN: '/auth/login',
+    REGISTER: '/auth/register',
+    ME: '/auth/me',
+  },
+  STREAMS: {
+    BASE: '/streams',
+    BY_ID: (id) => `/streams/${id}`,
+    START: (id) => `/streams/${id}/start`,
+    STOP: (id) => `/streams/${id}/stop`,
+    UPDATE: (id) => `/streams/${id}/update`,
+    WATCH: (id) => `/streams/${id}/watch`,
+    RANKING: '/streams/ranking',
+    TRENDING: '/streams/trending',
+    CATEGORIES: '/streams/categories',
+    RECOMMENDATIONS: '/streams/recommendations',
+  },
+  GIFTS: {
+    LIST: '/gifts',
+    SEND: '/gifts/send',
+  },
+  WALLET: {
+    BASE: '/wallet',
+    PURCHASE: '/wallet/purchase',
+    TRANSACTIONS: '/wallet/transactions',
+  },
+  USERS: {
+    BY_ID: (id) => `/users/${id}`,
+    PREFERENCES: '/users/preferences',
+  },
+  BROADCAST: (id) => `/broadcast/${id}`,
+  HEALTH: '/health',
+  ANALYTICS: '/analytics',
+};
+
+export default API;

--- a/frontend/src/config/routes.js
+++ b/frontend/src/config/routes.js
@@ -1,0 +1,14 @@
+/**
+ * Application route definitions for React Router.
+ */
+const ROUTES = {
+  HOME: '/',
+  LOGIN: '/login',
+  REGISTER: '/register',
+  BROADCAST: '/broadcast/:id',
+  WALLET: '/wallet',
+  PROFILE: '/profile',
+  STREAM: '/streams/:id',
+};
+
+export default ROUTES;

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -1,0 +1,17 @@
+/**
+ * Generic constants used across the frontend application.
+ */
+export const STORAGE_KEYS = {
+  TOKEN: 'livehot_token',
+  USER: 'livehot_user',
+};
+
+export const GIFT_RARITIES = ['COMMON', 'UNCOMMON', 'RARE', 'LEGENDARY'];
+
+export const COIN_PACKAGES = [
+  { id: 'basic', coins: 100, price: 9.99 },
+  { id: 'premium', coins: 500, price: 39.99 },
+  { id: 'vip', coins: 1000, price: 69.99 },
+];
+
+export const DEFAULT_CATEGORY = 'Entertainment';


### PR DESCRIPTION
## Summary
- add API endpoint definitions under `src/config`
- define application routes
- centralize common constants

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683f8419d43883219eea46990f5e65f6