### PR TITLE
Add frontend service and utility modules

### DIFF
--- a/frontend/src/services/livekit.js
+++ b/frontend/src/services/livekit.js
@@ -1,0 +1,28 @@
+import { connect } from '@livekit/client';
+
+let room = null;
+
+export async function connectToRoom(token, options = {}) {
+  const url = import.meta.env.VITE_LIVEKIT_WS_URL || 'wss://localhost:7880';
+  room = await connect(url, token, options);
+  return room;
+}
+
+export function getRoom() {
+  return room;
+}
+
+export function on(event, callback) {
+  if (room) {
+    room.on(event, callback);
+  }
+}
+
+export function disconnect() {
+  if (room) {
+    room.disconnect();
+    room = null;
+  }
+}
+
+export default { connectToRoom, disconnect, on, getRoom };

--- a/frontend/src/utils/formatters.js
+++ b/frontend/src/utils/formatters.js
@@ -1,0 +1,23 @@
+/**
+ * Functions for formatting common data types.
+ */
+
+export function formatDate(date, locale = 'pt-BR') {
+  return new Date(date).toLocaleDateString(locale);
+}
+
+export function formatNumber(number, locale = 'pt-BR') {
+  return new Intl.NumberFormat(locale).format(number);
+}
+
+export function formatCurrency(value, locale = 'pt-BR', currency = 'BRL') {
+  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value);
+}
+
+export function truncate(text, length = 50) {
+  return typeof text === 'string' && text.length > length
+    ? `${text.slice(0, length)}...`
+    : text;
+}
+
+export default { formatDate, formatNumber, formatCurrency, truncate };

--- a/frontend/src/utils/validators.js
+++ b/frontend/src/utils/validators.js
@@ -1,0 +1,21 @@
+/**
+ * Simple validation helpers for common inputs.
+ */
+
+export function isRequired(value) {
+  return value !== null && value !== undefined && value !== '';
+}
+
+export function isEmail(value) {
+  return /^\S+@\S+\.\S+$/.test(value);
+}
+
+export function minLength(value, length) {
+  return typeof value === 'string' && value.length >= length;
+}
+
+export function maxLength(value, length) {
+  return typeof value === 'string' && value.length <= length;
+}
+
+export default { isRequired, isEmail, minLength, maxLength };


### PR DESCRIPTION
## Summary
- add LiveKit service wrapper
- add generic formatters utilities
- add simple validators utilities

## Testing
- `pytest -q`
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_683f8642ddc083219bdb2575b89247f2