### PR TITLE
Add final UI components

### DIFF
--- a/frontend/src/components/auth/ProfilePage.js
+++ b/frontend/src/components/auth/ProfilePage.js
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import useAuth from '../../hooks/useAuth';
+
+function ProfilePage({ user: propUser, onUpdateProfile }) {
+  const { user: authUser } = useAuth();
+  const user = propUser || authUser;
+  const [form, setForm] = useState({
+    displayName: user?.displayName || '',
+    email: user?.email || '',
+  });
+
+  if (!user) {
+    return <p className="p-4">Usuário não autenticado</p>;
+  }
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (onUpdateProfile) {
+      onUpdateProfile(form);
+    }
+  };
+
+  return (
+    <div className="p-4 max-w-sm mx-auto">
+      <h2 className="text-lg font-bold mb-4">Perfil</h2>
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <input
+          type="text"
+          name="displayName"
+          className="w-full border p-2 rounded"
+          value={form.displayName}
+          onChange={handleChange}
+          placeholder="Nome de exibição"
+        />
+        <input
+          type="email"
+          name="email"
+          className="w-full border p-2 rounded"
+          value={form.email}
+          onChange={handleChange}
+          placeholder="Email"
+        />
+        <button type="submit" className="px-4 py-2 bg-pink-600 text-white rounded">
+          Salvar
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default ProfilePage;

--- a/frontend/src/components/chat/ChatBox.jsx
+++ b/frontend/src/components/chat/ChatBox.jsx
@@ -3,22 +3,25 @@ import useChat from '../../hooks/useChat';
 import ChatMessage from './ChatMessage';
 import ChatInput from './ChatInput';
 
-function ChatBox() {
-  const { messages, sendMessage } = useChat(
+function ChatBox({ messages: externalMessages, onSendMessage }) {
+  const { messages: internalMessages, sendMessage } = useChat(
     import.meta.env.VITE_WS_URL || 'ws://localhost:5000'
   );
+
+  const msgs = externalMessages ?? internalMessages;
+  const handleSend = onSendMessage ?? sendMessage;
 
   return (
     <div className="flex flex-col h-64 border-t">
       <div className="flex-1 overflow-y-auto p-4 space-y-2">
-        {messages.length === 0 && (
+        {msgs.length === 0 && (
           <p className="text-center text-slate-500">Chat em tempo real</p>
         )}
-        {messages.map((msg, index) => (
+        {msgs.map((msg, index) => (
           <ChatMessage key={index} message={msg} />
         ))}
       </div>
-      <ChatInput onSend={sendMessage} />
+      <ChatInput onSend={handleSend} />
     </div>
   );
 }

--- a/frontend/src/components/chat/ChatOverlay.js
+++ b/frontend/src/components/chat/ChatOverlay.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import ChatBox from './ChatBox';
+
+function ChatOverlay({ isOpen, messages = [], onSendMessage }) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="absolute inset-0 flex flex-col justify-end pointer-events-none">
+      <div className="pointer-events-auto">
+        <ChatBox messages={messages} onSendMessage={onSendMessage} />
+      </div>
+    </div>
+  );
+}
+
+export default ChatOverlay;

--- a/frontend/src/components/gifts/GiftAnimation.js
+++ b/frontend/src/components/gifts/GiftAnimation.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+function GiftAnimation({ giftType, isVisible, onComplete }) {
+  return (
+    <AnimatePresence>
+      {isVisible && (
+        <motion.div
+          className="absolute inset-0 flex items-center justify-center pointer-events-none"
+          initial={{ opacity: 0, scale: 0.5 }}
+          animate={{ opacity: 1, scale: 1 }}
+          exit={{ opacity: 0, scale: 0.5 }}
+          transition={{ duration: 0.6 }}
+          onAnimationComplete={onComplete}
+        >
+          <div className="text-4xl font-bold text-white drop-shadow-lg">
+            {giftType}
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+export default GiftAnimation;


### PR DESCRIPTION
## Summary
- add `ChatOverlay` component using `ChatBox`
- extend `ChatBox` to optionally use provided messages and send handler
- add animated `GiftAnimation` component
- implement simple `ProfilePage`

## Testing
- `npm test --prefix frontend` *(fails: no test specified)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683f8d90d98883218e5509ba6fabce9a