### PR TITLE
Fix useAuth export and extend uiSlice

### DIFF
--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -37,5 +37,7 @@ export default function useAuth() {
     localStorage.removeItem('token');
   };
 
-  return { user, token, login, register, logout };
+  const isAuthenticated = !!user;
+
+  return { user, token, login, register, logout, isAuthenticated };
 }

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -4,7 +4,7 @@ import VideoFeed from '../components/feed/VideoFeed';
 import ChatBox from '../components/chat/ChatBox';
 import GiftButton from '../components/gifts/GiftButton';
 import LoadingSpinner from '../components/common/LoadingSpinner';
-import { useAuth } from '../hooks/useAuth';
+import useAuth from '../hooks/useAuth';
 import { useStreams } from '../hooks/useStreams';
 
 function Home() {

--- a/frontend/src/store/uiSlice.js
+++ b/frontend/src/store/uiSlice.js
@@ -2,7 +2,13 @@ import { createSlice } from '@reduxjs/toolkit';
 
 const uiSlice = createSlice({
   name: 'ui',
-  initialState: { loading: false, error: null },
+  initialState: {
+    loading: false,
+    error: null,
+    showLogin: false,
+    showRegister: false,
+    notifications: [],
+  },
   reducers: {
     setLoading(state, action) {
       state.loading = action.payload;
@@ -13,9 +19,31 @@ const uiSlice = createSlice({
     clearError(state) {
       state.error = null;
     },
+    setShowLogin(state, action) {
+      state.showLogin = action.payload;
+    },
+    setShowRegister(state, action) {
+      state.showRegister = action.payload;
+    },
+    addNotification(state, action) {
+      state.notifications.push(action.payload);
+    },
+    removeNotification(state, action) {
+      state.notifications = state.notifications.filter(
+        (n) => n.id !== action.payload
+      );
+    },
   },
 });
 
-export const { setLoading, setError, clearError } = uiSlice.actions;
+export const {
+  setLoading,
+  setError,
+  clearError,
+  setShowLogin,
+  setShowRegister,
+  addNotification,
+  removeNotification,
+} = uiSlice.actions;
 
 export default uiSlice.reducer;


### PR DESCRIPTION
## Summary
- expose `isAuthenticated` from `useAuth`
- import `useAuth` correctly in `Home`
- store login/register modal state and notifications in `uiSlice`

## Testing
- `npm test` *(fails: no test specified)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f944eb6508321aca4f328d8ba186e