### PR TITLE
Fix CSS import order

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,8 +1,8 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 @import './styles/globals.css';
 @import './styles/components.css';
 @import './styles/themes.css';
 @import './styles/animations.css';
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;


### PR DESCRIPTION
## Summary
- reorder Tailwind directives in frontend `index.css`

## Testing
- `npm test --prefix frontend` *(fails: no test specified)*
- `pytest` *(no tests discovered)*

------
https://chatgpt.com/codex/tasks/task_e_683f96d0526483218e26331c4f93192d