### PR TITLE
Add CLI main entry and update run docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 install:
 pip install -r requirements.txt
 run-backend:
-python backend/main.py
+    poetry run python -m backend.main
 run-frontend:
 npm start --prefix frontend

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ window.API_BASE_URL = 'http://localhost:5000/api';
 3. **Executar servidor:**
 ```bash
 cd backend
-poetry run python main.py
+poetry run python -m backend.main
 ```
 As variáveis definidas no arquivo `.env` serão carregadas automaticamente. Configure `LIVEKIT_URL`, `LIVEKIT_API_KEY` e `LIVEKIT_API_SECRET` conforme necessário. Para uso local, defina `LIVEKIT_URL` como `ws://localhost:7880`.
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -745,3 +745,8 @@ def index():
             'viewer': {'email': 'viewer@livehot.app', 'password': 'password123'}
         }
     })
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 5000)))
+


### PR DESCRIPTION
## Summary
- add `__main__` block to backend entrypoint
- document running backend with module invocation
- update Makefile target to use poetry command

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840a93043688321a2f6a62487898277