### PR TITLE
Fix Home export causing 'App is not defined'

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -659,4 +659,4 @@ function Home() {
   );
 }
 
-export default App;
+export default Home;


### PR DESCRIPTION
## Summary
- correct the default export in `Home.jsx`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840aca9e1d083219ae46e48ce786ef2