### PR TITLE
Fix missing imports in App

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,8 @@ import { Routes, Route } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import Home from './pages/Home';
 import StreamPage from './pages/StreamPage';
+import WalletPage from './pages/WalletPage';
+import BroadcastPage from './pages/BroadcastPage';
 import LoginModal from './components/auth/LoginModal';
 import RegisterModal from './components/auth/RegisterModal';
 import Toast from './components/common/Toast';


### PR DESCRIPTION
## Summary
- add `WalletPage` and `BroadcastPage` imports so routes work

## Testing
- `npm test` *(fails: Error: no test specified)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6840b08d7c908321a0f15b06acce5432